### PR TITLE
feat: Improve result screen and error handling

### DIFF
--- a/app/src/main/java/com/example/scamdetectorapp/data/repository/AntiFraudRepository.kt
+++ b/app/src/main/java/com/example/scamdetectorapp/data/repository/AntiFraudRepository.kt
@@ -17,11 +17,13 @@ class AntiFraudRepository {
                     val response = api.getData(phoneNumber = input)
                     if (response.success) {
                         val data = response.data
+                        val riskLevel = data?.riskLevel ?: "NODATA"
                         ScanResult(
-                            riskLevel = data?.riskLevel ?: "UNKNOWN",
+                            isRisk = riskLevel != "NODATA" && riskLevel != "SAFE",
+                            riskLevel = riskLevel,
                             description = data?.description
                         )
-                    } else throwApiException(response.version)
+                    } else throwApiException(response.toString())
                 }
                 DetectionMode.URL -> {
                     var urlToCheck = input.trim()
@@ -31,23 +33,27 @@ class AntiFraudRepository {
                     val response = api.getUrlCheck(url = urlToCheck)
                     if (response.success) {
                         val data = response.data
+                        val riskLevel = data?.riskLevel ?: "NODATA"
                         ScanResult(
-                            riskLevel = data?.riskLevel ?: "UNKNOWN",
+                            isRisk = riskLevel != "NODATA" && riskLevel != "SAFE",
+                            riskLevel = riskLevel,
                             description = data?.description,
                             threatType = data?.threatType
                         )
-                    } else throwApiException(response.version)
+                    } else throwApiException(response.toString())
                 }
                 DetectionMode.TEXT -> {
                     val response = api.postAiCheck(body = AiCheckRequest(text = input))
                     if (response.success) {
                         val data = response.data
+                        val riskLevel = data?.riskLevel ?: "NODATA"
                         ScanResult(
-                            riskLevel = data?.riskLevel ?: "UNKNOWN",
+                            isRisk = riskLevel != "NODATA" && riskLevel != "SAFE",
+                            riskLevel = riskLevel,
                             description = data?.description,
                             suggestion = data?.suggestion
                         )
-                    } else throwApiException(response.version)
+                    } else throwApiException(response.toString())
                 }
             }
             Result.success(result)
@@ -56,7 +62,7 @@ class AntiFraudRepository {
         }
     }
 
-    private fun throwApiException(version: String): Nothing {
-        throw Exception("API 回傳失敗: $version")
+    private fun throwApiException(response: String): Nothing {
+        throw Exception("API 回傳失敗: $response")
     }
 }

--- a/app/src/main/java/com/example/scamdetectorapp/presentation/screens/detection/FraudResultScreen.kt
+++ b/app/src/main/java/com/example/scamdetectorapp/presentation/screens/detection/FraudResultScreen.kt
@@ -1,0 +1,164 @@
+package com.example.scamdetectorapp.presentation.screens.detection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.scamdetectorapp.R
+import com.example.scamdetectorapp.presentation.model.ScanUiModel
+
+@Composable
+fun FraudResultScreen(originalText: String, result: ScanUiModel, onBack: () -> Unit) {
+    val statusData = when {
+        result.score > 75 -> Triple(
+            "高風險威脅",
+            colorResource(id = R.color.scam_risk_red),
+            Icons.Default.Warning
+        )
+        result.score in 41..74 -> Triple(
+            "中風險威脅",
+            colorResource(id = R.color.scam_orange),
+            Icons.Default.Warning
+        )
+        result.score in 1..40 -> Triple(
+            "低風險威脅",
+            colorResource(id = R.color.scam_safe_green),
+            Icons.Filled.VerifiedUser
+        )
+        else -> Triple(
+            "查無資料",
+            colorResource(id = R.color.scam_neutral_gray),
+            Icons.Default.Search
+        )
+    }
+
+    val statusText = statusData.first
+    val statusColor = statusData.second
+    val statusIcon = statusData.third
+
+    val textWhite = MaterialTheme.colorScheme.onBackground
+    val textGrey = colorResource(R.color.scam_text_grey)
+    val surfaceColor = MaterialTheme.colorScheme.surface
+    val backgroundColor = MaterialTheme.colorScheme.background
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = textWhite)
+            }
+            Spacer(Modifier.width(8.dp))
+            Text("檢測結果", fontSize = 20.sp, fontWeight = FontWeight.Bold, color = textWhite)
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = surfaceColor),
+            shape = RoundedCornerShape(24.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(statusIcon, contentDescription = null, tint = statusColor, modifier = Modifier.size(64.dp))
+                Spacer(Modifier.height(16.dp))
+                Text(statusText, fontSize = 24.sp, fontWeight = FontWeight.Bold, color = statusColor)
+                Spacer(Modifier.height(8.dp))
+
+                Text(if(result.score > 0) "風險指數" else "", color = textGrey, fontSize = 12.sp)
+                Spacer(Modifier.height(8.dp))
+                if (result.score >= 0) {
+                    LinearProgressIndicator(
+                        progress = { result.score / 100f },
+                        color = statusColor,
+                        trackColor = backgroundColor,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        color = statusColor,
+                        trackColor = backgroundColor,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                    )
+                }
+
+                if(result.score >= 0) {
+                    Text("${result.score}%", color = textWhite, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 8.dp))
+                }
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Text("分析詳情", fontSize = 18.sp, fontWeight = FontWeight.Bold, color = textWhite)
+        Spacer(Modifier.height(16.dp))
+
+        result.reasons.forEach { reason ->
+            Row(modifier = Modifier.padding(bottom = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Info, contentDescription = null, tint = statusColor, modifier = Modifier.size(20.dp))
+                Spacer(Modifier.width(12.dp))
+                Text(reason, color = textGrey, fontSize = 15.sp)
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Text("原始內容", fontSize = 18.sp, fontWeight = FontWeight.Bold, color = textWhite)
+        Spacer(Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(surfaceColor, RoundedCornerShape(12.dp))
+                .padding(16.dp)
+        ) {
+            Text(originalText, color = textGrey, fontSize = 14.sp)
+        }
+
+        Spacer(Modifier.height(32.dp))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            Button(
+                onClick = onBack,
+                modifier = Modifier.weight(1f).height(50.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = surfaceColor)
+            ) {
+                Text("再測一次", color = textWhite)
+            }
+
+            Button(
+                onClick = { },
+                modifier = Modifier.weight(1f).height(50.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = statusColor)
+            ) {
+                Text(if(result.score > 0) "回報詐騙" else "完成", color = Color.White)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/scamdetectorapp/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/scamdetectorapp/presentation/viewmodel/MainViewModel.kt
@@ -34,8 +34,9 @@ class MainViewModel(
 
     fun scan(mode: DetectionMode, input: String) {
         _uiState.value = ScanUiState.Loading
+        val trimmedInput = input.trim()
         viewModelScope.launch {
-            val result = repository.scan(mode, input)
+            val result = repository.scan(mode, trimmedInput)
             result.fold(
                 onSuccess = { scanResult ->
                     val uiModel = mapToUiModel(scanResult)
@@ -55,31 +56,51 @@ class MainViewModel(
     }
 
     private fun mapToUiModel(result: ScanResult): ScanUiModel {
-        val reasons = mutableListOf<String>()
         val rLevel = result.riskLevel
-        val isRisk = result.isRisk
 
-        if (isRisk) {
-            reasons.add("風險等級: $rLevel")
-            result.description?.takeIf { it.isNotEmpty() }?.let { reasons.add(it) }
-            result.threatType?.takeIf { it.isNotEmpty() }?.let { reasons.add("威脅類型: $it") }
-            result.suggestion?.takeIf { it.isNotEmpty() }?.let { reasons.add("建議: $it") }
-        } else {
-            reasons.add("無詐騙特徵")
-            reasons.add("正規網域/號碼/內容")
+        val score = when (rLevel?.uppercase()) {
+            "HIGH" -> 85
+            "MEDIUM" -> 60
+            "LOW" -> 20
+            "SAFE" -> 10
+            "NODATA" -> 0
+            else -> 0
         }
 
-        if (reasons.isEmpty()) {
-            reasons.add("無詳細資訊")
+        val reasons = mutableListOf<String>()
+        val title: String
+
+        when (rLevel?.uppercase()) {
+            "HIGH", "MEDIUM", "LOW" -> {
+                title = when (rLevel.uppercase()) {
+                    "HIGH" -> "高風險威脅"
+                    "MEDIUM" -> "中風險威脅"
+                    else -> "低風險威脅"
+                }
+                reasons.add("風險等級: $rLevel")
+                result.description?.takeIf { it.isNotEmpty() }?.let { reasons.add(it) }
+                result.threatType?.takeIf { it.isNotEmpty() }?.let { reasons.add("威脅類型: $it") }
+                result.suggestion?.takeIf { it.isNotEmpty() }?.let { reasons.add("建議: $it") }
+            }
+            "SAFE" -> {
+                title = "安全內容"
+                reasons.add("無詐騙特徵")
+                reasons.add("正規網域/號碼/內容")
+            }
+            else -> { // Catches NODATA and any other case
+                title = "查無資料"
+                reasons.add("資料庫暫無此紀錄")
+            }
         }
 
         return ScanUiModel(
-            isSafe = !isRisk,
-            score = if (isRisk) 30 else 95,
-            title = if (isRisk) "高風險威脅" else "安全內容",
+            isSafe = !result.isRisk,
+            score = score,
+            title = title,
             reasons = reasons
         )
     }
+
 
     companion object {
         val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {

--- a/app/src/main/res/drawable/ic_shield_check.xml
+++ b/app/src/main/res/drawable/ic_shield_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16-1.26 9-6.45 9-12V5l-9,-4zm-2,15l-3.5,-3.5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z" />
+</vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,9 +8,14 @@
       <color name="black">#FF000000</color>
       <color name="white">#FFFFFFFF</color>
 
-      <color name="scam_background">#0B1221</color> <color name="scam_surface">#1C2436</color>    <color name="scam_primary">#2979FF</color>    <color name="scam_text_white">#FFFFFF</color>
+      <color name="scam_background">#0B1221</color>
+      <color name="scam_surface">#1C2436</color>
+      <color name="scam_primary">#2979FF</color>
+      <color name="scam_text_white">#FFFFFF</color>
       <color name="scam_text_grey">#8F9BB3</color>
-      <color name="scam_safe_green">#00C853</color>
+      <color name="scam_safe_green">#4CAF50</color>
       <color name="scam_risk_red">#D32F2F</color>
       <color name="scam_gold_warning">#FFD700</color>
+      <color name="scam_orange">#FFA500</color>
+      <color name="scam_neutral_gray">#808080</color>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.configuration-cache=true
 
 # App Configuration
 BASE_URL=https://antifraud-gateway.lyc-dev.workers.dev/


### PR DESCRIPTION
Refactors the detection result presentation by introducing a dedicated `FraudResultScreen` with tiered risk levels (High, Medium, Low, No Data) and corresponding UI states.

Key changes:
- Add a distinct `ErrorScreen` to handle API failures and other errors gracefully.
- Implement a `FraudResultScreen` to display categorized scan results.
- Update `MainViewModel` to map API responses (`HIGH`, `MEDIUM`, `LOW`, `SAFE`, `NODATA`) to specific scores and titles.
- Enhance the `AntiFraudRepository` to provide more detailed error information on API failures.
- Add new colors and a drawable icon to support the updated UI.